### PR TITLE
feat: update canvas cursor for region selection

### DIFF
--- a/content.js
+++ b/content.js
@@ -304,6 +304,7 @@ function startRegionSelection() {
   // Enable pointer events on canvas for selection
   debugLog('EVENTS', 'Enabling pointer events on canvas');
   canvas.style.pointerEvents = 'all';
+  canvas.style.cursor = 'crosshair';
   
   // Verify pointer events were set
   const computedPointerEvents = window.getComputedStyle(canvas).pointerEvents;
@@ -336,6 +337,7 @@ function exitRegionSelection() {
   
   if (canvas) {
     canvas.style.pointerEvents = 'none';
+    canvas.style.cursor = '';
     canvas.removeEventListener('mousedown', handleSelectionStart);
     canvas.removeEventListener('mousemove', handleSelectionDraw);
   }


### PR DESCRIPTION
## Summary
- ensure region selection canvas shows a crosshair cursor
- reset the canvas cursor when leaving selection mode

## Testing
- `node /tmp/verify.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cbb7d6bc832e93633eed9673cf4c